### PR TITLE
added a v2 manifest for Firefox support

### DIFF
--- a/browser/chrome/manifest_v2.json
+++ b/browser/chrome/manifest_v2.json
@@ -1,0 +1,26 @@
+{
+    "manifest_version": 2,
+    "name": "Twitter Screen Name Time Machine",
+    "version": "0.1.0",
+    "content_scripts": [
+        {
+            "run_at": "document_end",
+            "js": [
+                "memory.lol.js"
+            ],
+            "css": [
+                "memory.lol.css"
+            ],
+            "matches": [
+                "https://twitter.com/*",
+                "https://mobile.twitter.com/*"
+            ]
+        }
+    ],
+    "permissions": [
+        "https://memory.lol/*"
+    ],
+    "background": {
+        "scripts": ["background.js"]
+    }
+}


### PR DESCRIPTION
Firefox seems to currently only support Manifest v2.

Tested working on Firefox 102.0.1 (64-bit) on Windows 10

Testing:
remove (the v3) manifest.json and rename manifest_v2.json to manifest.json, then zip all the contents with the extension .xpi.
Add-on can temporarily be loaded in about:debugging